### PR TITLE
use "pipeline-chain" verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Goals
 Architecture
 ============
 * Keep the "Russian Doll" model
+  * A pipeline chain of "behaviors" (much like middleware in [OWIN](http://owin.org/))
 * Combine FubuMVC and FubuTransportation into one library
 * Use OWIN AppFunc as the new "Behavior", which effectively means "async by default"
 * Build on top of the new DNX .Net runtime. Hopefully shoot for CoreCLR support


### PR DESCRIPTION
After reading some posts, such as [the jasper reboot](http://jeremydmiller.com/2015/08/06/gutting-fubumvc-and-rebooting-as-jasper/) it seems to me that getting buy in from the Microsoft entrenched is a matter of speaking their language. It takes a while to understand the idea of the "Russian doll" model while most people who have been exposed to OWIN or Web API 2 readily understand "middleware" and "pipeline chain, respectively.

I've only been looking at Fubu code for the last month and a half, I'm particularly impressed that this pre-dates MVC but think it can hand off some of the heavy lifting it had been forced to do (because a lot of the plumbing didn't exist on Microsoft's side).