### PR TITLE
Move log message to after message deserialization

### DIFF
--- a/src/JasperBus/Runtime/Invocation/HandlerPipeline.cs
+++ b/src/JasperBus/Runtime/Invocation/HandlerPipeline.cs
@@ -60,10 +60,9 @@ namespace JasperBus.Runtime.Invocation
                 }
                 else
                 {
-                    Logger.Received(envelope);
-
                     deserialize(envelope, receiver);
 
+                    Logger.Received(envelope);
 
                     await ProcessMessage(envelope, context).ConfigureAwait(false);
                 }
@@ -72,7 +71,7 @@ namespace JasperBus.Runtime.Invocation
 
         private void deserialize(Envelope envelope, ChannelNode receiver)
         {
-// TODO -- Not super duper wild about this one.
+            // TODO -- Not super duper wild about this one.
             if (envelope.Message == null)
             {
                 envelope.Message = _serializer.Deserialize(envelope, receiver);


### PR DESCRIPTION
The console logger was blowing up because it attempts to use `.Message`, which was null.