### PR TITLE
Ip binding

### DIFF
--- a/src/Jasper.Testing/Bus/Lightweight/Protocol/ProtocolContext.cs
+++ b/src/Jasper.Testing/Bus/Lightweight/Protocol/ProtocolContext.cs
@@ -29,7 +29,7 @@ namespace Jasper.Testing.Bus.Lightweight.Protocol
 
         public ProtocolContext()
         {
-            _listener = new ListeningAgent(theReceiver, thePort, "durable", CancellationToken.None);
+            _listener = new ListeningAgent(theReceiver, theAddress, thePort, "durable", CancellationToken.None);
 
 
 

--- a/src/Jasper/Bus/Transports/Receiving/ListeningAgent.cs
+++ b/src/Jasper/Bus/Transports/Receiving/ListeningAgent.cs
@@ -24,13 +24,14 @@ namespace Jasper.Bus.Transports.Receiving
         private readonly ActionBlock<Socket> _socketHandling;
         private readonly Uri _uri;
 
-        public ListeningAgent(IReceiverCallback callback, int port, string protocol, CancellationToken cancellationToken)
+        public ListeningAgent(IReceiverCallback callback, IPAddress ipaddr, int port, string protocol, CancellationToken cancellationToken)
         {
+            
             Port = port;
             _callback = callback;
             _cancellationToken = cancellationToken;
 
-            _listener = new TcpListener(new IPEndPoint(IPAddress.Any, port));
+            _listener = new TcpListener(new IPEndPoint(ipaddr, port));
             _listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
             _socketHandling = new ActionBlock<Socket>(async s =>
@@ -41,7 +42,7 @@ namespace Jasper.Bus.Transports.Receiving
                 }
             });
 
-            _uri = $"{protocol}://{Environment.MachineName}:{port}/".ToUri();
+            _uri = $"{protocol}://{ipaddr}:{port}/".ToUri();
 
         }
 

--- a/src/Jasper/Bus/Transports/Receiving/SocketListeningAgent.cs
+++ b/src/Jasper/Bus/Transports/Receiving/SocketListeningAgent.cs
@@ -11,24 +11,25 @@ namespace Jasper.Bus.Transports.Receiving
 {
     public class SocketListeningAgent : IListeningAgent
     {
+        private readonly IPAddress _ipaddr;
         private readonly int _port;
         private readonly CancellationToken _cancellationToken;
         private TcpListener _listener;
         private ActionBlock<Socket> _socketHandling;
         private Task _receivingLoop;
 
-        public SocketListeningAgent(int port, CancellationToken cancellationToken)
+        public SocketListeningAgent(IPAddress ipaddr, int port, CancellationToken cancellationToken)
         {
             _port = port;
+            _ipaddr = ipaddr;
             _cancellationToken = cancellationToken;
 
-
-            Address = $"tcp://{Environment.MachineName}:{port}/".ToUri();
+            Address = $"tcp://{ipaddr}:{port}/".ToUri();
         }
 
         public void Start(IReceiverCallback callback)
         {
-            _listener = new TcpListener(new IPEndPoint(IPAddress.Loopback, _port));
+            _listener = new TcpListener(new IPEndPoint(_ipaddr, _port));
             _listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 
             _socketHandling = new ActionBlock<Socket>(async s =>

--- a/src/Jasper/Bus/Transports/Tcp/TcpTransport.cs
+++ b/src/Jasper/Bus/Transports/Tcp/TcpTransport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using Baseline;
 using Jasper.Bus.Logging;
@@ -59,7 +60,7 @@ namespace Jasper.Bus.Transports.Tcp
         {
             if (settings.StateFor(Protocol) == TransportState.Disabled) return;
 
-            _workerQueue = workers;
+           _workerQueue = workers;
 
             var incoming = settings.Listeners.Where(x => x.Scheme == Protocol).ToArray();
 
@@ -67,7 +68,17 @@ namespace Jasper.Bus.Transports.Tcp
 
             foreach (var uri in incoming)
             {
-                var agent = new SocketListeningAgent(uri.Port, settings.Cancellation);
+                // check the uri for an ip address to bind to
+                if (uri.HostNameType == UriHostNameType.IPv4 || uri.HostNameType == UriHostNameType.IPv6)
+                {
+                    IPAddress ipaddr = IPAddress.Parse(uri.Host);
+                    agent = new SocketListeningAgent(ipaddr, uri.Port, settings.Cancellation);
+                } else if (uri.HostName == "localhost") {
+                    agent = new SocketListeningAgent(IPAddress.Loopback, uri.Port, settings.Cancellation);
+                } else {
+                    agent = new SocketListeningAgent(IPAddress.Any, uri.Port, settings.Cancellation);
+                }
+                
                 var listener = uri.IsDurable()
                     ? _persistence.BuildListener(agent, _workerQueue)
                     : new LightweightListener( _workerQueue, _logger, agent);

--- a/src/Jasper/Bus/Transports/Tcp/TcpTransport.cs
+++ b/src/Jasper/Bus/Transports/Tcp/TcpTransport.cs
@@ -68,12 +68,13 @@ namespace Jasper.Bus.Transports.Tcp
 
             foreach (var uri in incoming)
             {
+                SocketListeningAgent agent;
                 // check the uri for an ip address to bind to
                 if (uri.HostNameType == UriHostNameType.IPv4 || uri.HostNameType == UriHostNameType.IPv6)
                 {
                     IPAddress ipaddr = IPAddress.Parse(uri.Host);
                     agent = new SocketListeningAgent(ipaddr, uri.Port, settings.Cancellation);
-                } else if (uri.HostName == "localhost") {
+                } else if (uri.Host == "localhost") {
                     agent = new SocketListeningAgent(IPAddress.Loopback, uri.Port, settings.Cancellation);
                 } else {
                     agent = new SocketListeningAgent(IPAddress.Any, uri.Port, settings.Cancellation);

--- a/src/Jasper/Util/UriExtensions.cs
+++ b/src/Jasper/Util/UriExtensions.cs
@@ -61,11 +61,11 @@ namespace Jasper.Util
             {
                 case "tcp":
                     return uri.IsDurable()
-                            ? $"tcp://localhost:{uri.Port}/{TransportConstants.Durable}".ToUri()
-                            : $"tcp://localhost:{uri.Port}".ToUri();
+                            ? $"tcp://{uri.Host}:{uri.Port}/{TransportConstants.Durable}".ToUri()
+                            : $"tcp://{uri.Host}:{uri.Port}".ToUri();
 
                 case "durable":
-                    return $"tcp://localhost:{uri.Port}/{TransportConstants.Durable}".ToUri();
+                    return $"tcp://{uri.Host}:{uri.Port}/{TransportConstants.Durable}".ToUri();
 
                 default:
                     return uri;


### PR DESCRIPTION
I had some issues with the receiver binding to localhost (or binding to all my IP address depending on which version I used, master or the 0.5 nuget), basically it was ignoring the host portion of the configuration uri, eg. tcp://192.168.0.1:2344 we being bound to either 127.0.0.1, or 0.0.0.0 

This PR is an option/attempt to fix that behavior and bind to the specified IP, localhost or 0.0.0.0 depending on the uri.  More work should probably be done to do a DNS resolve on other hostnames besides localhost, but I'm lazy and don't want to deal with the exception when the hostname doesn't translate to a local IP.