### PR TITLE
Get Jasper building with the latest Lamar

### DIFF
--- a/src/Jasper.Testing/ContainerExtensions.cs
+++ b/src/Jasper.Testing/ContainerExtensions.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq;
-using Baseline;
 using Lamar;
-using Lamar.IoC;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 
@@ -25,7 +23,7 @@ namespace Jasper.Testing
 
         public static IContainer DefaultRegistrationIs<T>(this IContainer container, T value) where T : class
         {
-            container.Model.For<T>().Default.Resolve(container.As<Scope>()).ShouldBeTheSameAs(value);
+            container.Model.For<T>().Default.Resolve().ShouldBeTheSameAs(value);
 
             return container;
         }

--- a/src/Jasper/Conneg/ForwardingRegistration.cs
+++ b/src/Jasper/Conneg/ForwardingRegistration.cs
@@ -1,7 +1,7 @@
 using System.Linq;
+using Lamar;
 using Lamar.Scanning;
 using Lamar.Scanning.Conventions;
-using Microsoft.Extensions.DependencyInjection;
 using TypeExtensions = Baseline.TypeExtensions;
 
 namespace Jasper.Conneg
@@ -15,7 +15,7 @@ namespace Jasper.Conneg
             _forwarders = forwarders;
         }
 
-        public void ScanTypes(TypeSet types, IServiceCollection services)
+        public void ScanTypes(TypeSet types, ServiceRegistry services)
         {
             var forwardingTypes = types.FindTypes(TypeClassification.Closed)
                 .Where(t => TypeExtensions.Closes(t, typeof(IForwardsTo<>)));

--- a/src/Jasper/Jasper.csproj
+++ b/src/Jasper/Jasper.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Baseline" Version="1.4.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.1.1" />
-    <PackageReference Include="Lamar" Version="0.9.9" />
+    <PackageReference Include="Lamar" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />


### PR DESCRIPTION
Getting jasper working with the latest Lamar. Lama's `IRegistrationConvention` interface changed so it causes: 

```
TypeLoadException: Method 'ScanTypes' in type 'Jasper.Conneg.ForwardingRegistration' from assembly 'Jasper, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.
```