### PR TITLE
Do not add jasper's middleware when routing is disabled

### DIFF
--- a/src/Jasper/WebHostBuilderExtensions.cs
+++ b/src/Jasper/WebHostBuilderExtensions.cs
@@ -183,6 +183,13 @@ namespace Jasper
         {
             return app =>
             {
+                var httpSettings = app.ApplicationServices.GetRequiredService<HttpSettings>();
+                if(!httpSettings.Enabled)
+                {
+                    next(app);
+                    return;
+                }
+
                 var logger = app.ApplicationServices.GetRequiredService<ILogger<HttpSettings>>();
 
                 app.Use(inner =>


### PR DESCRIPTION
This changes the `RegisterJasperStartupFilter` to simply move on to the next filter in the chain when Jasper's "Http features" are disabled with `HttpSettings.Enabled = false`.