### PR TITLE
Fix DurableLoopbackSendingAgent.StoreAndForward()

### DIFF
--- a/src/Jasper/Messaging/MessagingRoot.cs
+++ b/src/Jasper/Messaging/MessagingRoot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -156,7 +156,7 @@ namespace Jasper.Messaging
 
         public ISendingAgent BuildDurableLoopbackAgent(Uri destination)
         {
-            return new DurableLoopbackSendingAgent(destination, Workers, Persistence, Serialization, _transportLogger);
+            return new DurableLoopbackSendingAgent(destination, Workers, Persistence, Serialization, _transportLogger, Options);
         }
 
         public IListener BuildDurableListener(IListeningAgent agent)

--- a/src/Jasper/WebHostBuilderExtensions.cs
+++ b/src/Jasper/WebHostBuilderExtensions.cs
@@ -183,6 +183,13 @@ namespace Jasper
         {
             return app =>
             {
+                var httpSettings = app.ApplicationServices.GetRequiredService<HttpSettings>();
+                if(!httpSettings.Enabled)
+                {
+                    next(app);
+                    return;
+                }
+
                 var logger = app.ApplicationServices.GetRequiredService<ILogger<HttpSettings>>();
 
                 app.Use(inner =>


### PR DESCRIPTION
Fixed a couple of issues in the DurabilityLoopbackSendingAgent where an envelop could be queued to be handled on the current node while being stored as if it were available for any node to handle, causing the possibility of duplicate executions.

See previous gitter conversation.