### PR TITLE
Fixed an issue with CommandBuilder

### DIFF
--- a/src/Jasper.Persistence.Database/CommandBuilder.cs
+++ b/src/Jasper.Persistence.Database/CommandBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Text;
@@ -12,11 +12,12 @@ namespace Jasper.Persistence.Database
         private readonly DbCommand _command;
 
 
-        private readonly StringBuilder _sql = new StringBuilder();
+        private readonly StringBuilder _sql;
 
         public CommandBuilder(DbCommand command)
         {
             _command = command;
+            _sql = new StringBuilder(command.CommandText);
         }
 
 


### PR DESCRIPTION
When command builder is initialized with an existing command that already has it's `CommandText` property set, the `_sql` is left empty.  This means that new sql that is added to the command builder either overwrites the existing command text, losing the original command completely.  Or the command is set to an empty string when `Apply()` is called an no additional SQL is appended to the builder.

This PR fixes that by initializing the `_sql` field with the `CommandText` of the initializing command.