### PR TITLE
Corrects an issue where invoking a command requires the exact result type in order to get a result

### DIFF
--- a/src/Jasper.Testing/Acceptance/CommandBusTests.cs
+++ b/src/Jasper.Testing/Acceptance/CommandBusTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -207,6 +207,14 @@ namespace Jasper.Testing.Acceptance
                 .ShouldBeNull();
         }
 
+        [Fact]
+        public async Task should_return_result_for_command_with_castable_result()
+        {
+            var answer = await Bus.Invoke<IAnswer>(new Question { One = 3, Two = 4 });
+
+            answer.Sum.ShouldBe(7);
+            answer.Product.ShouldBe(12);
+        }
     }
 
 
@@ -269,7 +277,13 @@ namespace Jasper.Testing.Acceptance
         public int Two { get; set; }
     }
 
-    public class Answer
+    public interface IAnswer
+    {
+        int Sum { get; }
+        int Product { get; }
+    }
+
+    public class Answer : IAnswer
     {
         public int Sum { get; set; }
         public int Product { get; set; }

--- a/src/Jasper/Runtime/MessageContext.cs
+++ b/src/Jasper/Runtime/MessageContext.cs
@@ -107,7 +107,7 @@ namespace Jasper.Runtime
 
         public async Task EnqueueCascading(object message)
         {
-            if (Envelope.ResponseType != null && message?.GetType() == Envelope.ResponseType)
+            if (Envelope.ResponseType != null && (message?.GetType() == Envelope.ResponseType || Envelope.ResponseType.IsAssignableFrom(message?.GetType())))
             {
                 Envelope.Response = message;
                 return;


### PR DESCRIPTION
**Problem**:
When invoking a command that expects a result, the expected result type **must match exactly** the result type generated by the command handler or the result will always be `null`.

This pull request proposes to solve that problem by making the result assignment checking in the `MessageContext.EnqueueCascading()` more flexible by checking to see if the expected result type is at least assignable from the actual result type.