### PR TITLE
Fix database schema issues

### DIFF
--- a/src/Jasper.Persistence.EntityFrameworkCore/JasperEnvelopeEntityFrameworkCoreExtensions.cs
+++ b/src/Jasper.Persistence.EntityFrameworkCore/JasperEnvelopeEntityFrameworkCoreExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
@@ -41,10 +40,10 @@ namespace Jasper.Persistence.EntityFrameworkCore
         {
             builder.Entity<IncomingEnvelope>(map =>
             {
-                map.ToTable($"jasper_incoming_envelopes");
+                map.ToTable(string.IsNullOrEmpty(schemaName) ? "jasper_incoming_envelopes" : $"{schemaName}.jasper_incoming_envelopes");
                 map.HasKey(x => x.Id);
                 map.Property(x => x.OwnerId).HasColumnName("owner_id");
-                map.Property(x => x.Status).HasColumnName("status");
+                map.Property(x => x.Status).HasColumnName("status").HasConversion<string>();
                 map.Property(x => x.ExecutionTime).HasColumnName("execution_time");
                 map.Property(x => x.Attempts).HasColumnName("attempts");
                 map.Property(x => x.Body).HasColumnName("body");
@@ -52,7 +51,7 @@ namespace Jasper.Persistence.EntityFrameworkCore
 
             builder.Entity<OutgoingEnvelope>(map =>
             {
-                map.ToTable($"jasper_outgoing_envelopes");
+                map.ToTable(string.IsNullOrEmpty(schemaName) ? "jasper_outgoing_envelopes" : $"{schemaName}.jasper_outgoing_envelopes");
                 map.HasKey(x => x.Id);
                 map.Property(x => x.OwnerId).HasColumnName("owner_id");
                 map.Property(x => x.Destination).HasColumnName("destination");
@@ -62,7 +61,7 @@ namespace Jasper.Persistence.EntityFrameworkCore
 
             builder.Entity<DeadLetterEnvelope>(map =>
             {
-                map.ToTable($"{schemaName}.jasper_dead_letters");
+                map.ToTable(string.IsNullOrEmpty(schemaName) ? "jasper_dead_letters" : $"{schemaName}.jasper_dead_letters");
                 map.HasKey(x => x.Id);
                 map.Property(x => x.Source).HasColumnName("source");
                 map.Property(x => x.MessageType).HasColumnName("message_type");

--- a/src/Jasper.Persistence.Postgresql/Schema/Creation.sql
+++ b/src/Jasper.Persistence.Postgresql/Schema/Creation.sql
@@ -27,9 +27,9 @@ create table if not exists %SCHEMA%.jasper_dead_letters
   source VARCHAR(250),
   message_type VARCHAR(250),
   explanation VARCHAR(250),
-  exception_text VARCHAR,
+  exception_text VARCHAR(MAX),
   exception_type VARCHAR(250),
-  exception_message VARCHAR(250),
+  exception_message VARCHAR(MAX),
 
 	body bytea not null
 );

--- a/src/Jasper.Persistence.SqlServer/Schema/Creation.sql
+++ b/src/Jasper.Persistence.SqlServer/Schema/Creation.sql
@@ -29,7 +29,7 @@ create table %SCHEMA%.jasper_dead_letters
   explanation VARCHAR(250),
   exception_text VARCHAR(MAX),
   exception_type VARCHAR(250),
-  exception_message VARCHAR(MAX)
+  exception_message VARCHAR(MAX),
 
 	body varbinary(max) not null
 );

--- a/src/Jasper.Persistence.SqlServer/Schema/Creation.sql
+++ b/src/Jasper.Persistence.SqlServer/Schema/Creation.sql
@@ -29,7 +29,7 @@ create table %SCHEMA%.jasper_dead_letters
   explanation VARCHAR(250),
   exception_text VARCHAR(MAX),
   exception_type VARCHAR(250),
-  exception_message VARCHAR(250),
+  exception_message VARCHAR(MAX)
 
 	body varbinary(max) not null
 );


### PR DESCRIPTION
This PR:

- stores enums as strings for ef core to make it consistent with the creation.sql scripts
- sets character limit to MAX for exception_text and exception_message columns in the dead letter table
- prepends db schema name to all jasper tables 